### PR TITLE
Bug fix collecting data from opensearch

### DIFF
--- a/data_collector/collector.py
+++ b/data_collector/collector.py
@@ -14,60 +14,89 @@ class Collector:
         self.os_client = OpenSearch(es_server, verify_certs=False, http_compress=True, timeout=30)
 
     def collect(self, from_date: datetime, to: datetime):
-        """Collects data from the elastic search"""
+        """Collects data from the elastic search using search_after"""
         start_time = time.time()
         data = []
         from_timestamp = from_date.strftime("%Y-%m-%dT%H:%M:%SZ")
         to_timestamp = to.strftime("%Y-%m-%dT%H:%M:%SZ")
+
         logger.info(f"Elasticsearch index: {self.es_index}, benchmark: {self.config['benchmark']}")
+        
         query = Q(
             "bool",
             must_not=[Q("term", **{"jobConfig.name.keyword": "garbage-collection"})],
             must=[
-                    Q("term", **{"jobConfig.name.keyword": self.config["benchmark"]}),
-                    Q("range", **{"timestamp": {"gte": from_timestamp, "lte": to_timestamp}}),
-                ],
+                Q("term", **{"jobConfig.name.keyword": self.config["benchmark"]}),
+                Q("range", **{"timestamp": {"gte": from_timestamp, "lte": to_timestamp}}),
+            ],
         )
+
         logger.debug(f"Constructed Elasticsearch query: {query.to_dict()}")
-        s = (
-            Search(using=self.os_client, index=self.es_index)
-            .filter("term", **{"metricName.keyword": "jobSummary"})
-            .params(scroll="5m", size=100)
-            .query(query)
-        )
-        # Use scan to get all results
-        try:
-            for hit in s.scan():
-                run_data = {}
-                jobSummary = hit.to_dict()
-                uuid = jobSummary.get("uuid")
-                if not uuid:
-                    logger.warning("Missing UUID in jobSummary, skipping entry.")
-                    continue
-                logging.debug(f"Processing UUID: {uuid}")
-                if uuid not in run_data:
-                    logger.debug("UUID not present in run data, adding it")
-                    run_data[uuid] = {"metadata": {}, "metrics": {}}
 
-                for field in self.config["metadata"]:
-                    if field in jobSummary:
-                        run_data[uuid]["metadata"][field] = jobSummary[field]
-                    elif "jobConfig" in jobSummary and field in jobSummary["jobConfig"]:
-                        run_data[uuid]["metadata"].setdefault("jobConfig", {})[field] = jobSummary["jobConfig"][field]
+        page_size = 100
+        sort_field = "timestamp"
+        search_after = None
+        total_hits = 0
 
-                metrics, count_verified = self._metrics_by_uuid(uuid)
-                if count_verified:
-                    run_data[uuid]["metrics"] = metrics
-                else:
-                    logger.debug(f"No verified metrics for UUID {uuid}, skipping.")
-                    continue
-                data.append(run_data)
+        while True:
+            s = (
+                Search(using=self.os_client, index=self.es_index)
+                .filter("term", **{"metricName.keyword": "jobSummary"})
+                .query(query)
+                .sort({sort_field: "asc"})
+                .extra(size=page_size)
+            )
 
-        except Exception as e:
-            logger.warning(f"Scroll context lost: {e}, continuing with partial results.")
-        
+            if search_after:
+                s = s.extra(search_after=search_after)
+
+            try:
+                response = s.execute()
+                hits = response.hits
+
+                if not hits:
+                    break
+
+                for hit in hits:
+                    run_data = {}
+                    jobSummary = hit.to_dict()
+                    uuid = jobSummary.get("uuid")
+
+                    if not uuid:
+                        logger.warning("Missing UUID in jobSummary, skipping entry.")
+                        continue
+
+                    logger.debug(f"Processing UUID: {uuid}")
+
+                    if uuid not in run_data:
+                        logger.debug("UUID not present in run data, adding it")
+                        run_data[uuid] = {"metadata": {}, "metrics": {}}
+
+                    for field in self.config["metadata"]:
+                        if field in jobSummary:
+                            run_data[uuid]["metadata"][field] = jobSummary[field]
+                        elif "jobConfig" in jobSummary and field in jobSummary["jobConfig"]:
+                            run_data[uuid]["metadata"].setdefault("jobConfig", {})[field] = jobSummary["jobConfig"][field]
+
+                    metrics, count_verified = self._metrics_by_uuid(uuid)
+                    if count_verified:
+                        run_data[uuid]["metrics"] = metrics
+                    else:
+                        logger.debug(f"No verified metrics for UUID {uuid}, skipping.")
+                        continue
+
+                    data.append(run_data)
+                    total_hits += 1
+
+                # Prepare for next page
+                search_after = hits[-1].meta.sort
+
+            except Exception as e:
+                logger.warning(f"Search failed: {e}, continuing with partial results.")
+                break
+
         elapsed = time.time() - start_time
-        logger.info(f"Data collection completed in {elapsed:.2f} seconds.")
+        logger.info(f"Data collection completed in {elapsed:.2f} seconds. Retrieved {total_hits} documents.")
         return data
 
     def _metrics_by_uuid(self, uuid: str):

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,6 @@
 
 from setuptools import setup, find_packages
 
-with open("README.rst") as readme_file:
-    readme = readme_file.read()
-
-with open("HISTORY.rst") as history_file:
-    history = history_file.read()
-
 requirements = []
 
 setup_requirements = []
@@ -39,10 +33,10 @@ setup(
     },
     install_requires=requirements,
     license="Apache Software License 2.0",
-    long_description=readme + "\n\n" + history,
     include_package_data=True,
     keywords="data_collector",
     name="data_collector",
+    py_modules=["main"],
     packages=find_packages(include=["data_collector", "data_collector.*"]),
     setup_requires=setup_requirements,
     test_suite="tests",


### PR DESCRIPTION
### Description
Previously scroll function used to fail while fetching data from opensearch. Fixing it using search_after.

### Testing
```
2025-07-31 01:07:19,478 [opensearch:base.py:258] INFO: POST https://XXXXXX:443/XXXXXX-XXXXXX-index*/_search [status:200 request:0.047s]
2025-07-31 01:07:19,490 [data_collector.collector:collector.py:156] INFO: Data collection completed in 15699.18 seconds. Retrieved 1529 documents.
2025-07-31 01:07:33,961 [botocore.credentials:credentials.py:1352] INFO: Found credentials in shared credentials file: ~/.aws/credentials
2025-07-31 01:07:39,082 [data_collector.s3:s3.py:22] INFO: ✅ Uploaded chunk to s3://XXXXXX-s3-bucket/XXXXXX/output_2025-01-30T18:20:37Z_2025-07-31T04:45:40Z_chunk_1.csv
```